### PR TITLE
Add arena init to SSR tests to avoid panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,9 +1583,9 @@ dependencies = [
 
 [[package]]
 name = "reactive_graph"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27f54685c1416af1f323a0c40e71cbdae281a1ebc623591790d367222d0ac65"
+checksum = "04db00da5327bfd67a75b8d39dd1e8dff14509f375f0618110e30d28d4fbea0d"
 dependencies = [
  "any_spawner",
  "async-lock",
@@ -2029,6 +2029,7 @@ dependencies = [
  "futures",
  "leptos",
  "leptos_async_signal",
+ "reactive_graph",
  "tokio",
 ]
 

--- a/tests_ssr/Cargo.toml
+++ b/tests_ssr/Cargo.toml
@@ -11,4 +11,5 @@ expect-test = "1.5"
 futures = "0.3"
 leptos = { workspace = true, features = ["ssr"] }
 leptos_async_signal = { path = "../leptos_async_signal", features = ["ssr"] }
+reactive_graph = { version = "0.1" }
 tokio.workspace = true

--- a/tests_ssr/src/lib.rs
+++ b/tests_ssr/src/lib.rs
@@ -2,3 +2,12 @@ pub async fn fetch_data() -> (String, String) {
     tokio::time::sleep(std::time::Duration::from_millis(1)).await;
     ("Hello world".to_string(), "42".to_string())
 }
+
+pub fn init_test() {
+    // Set async executor
+    any_spawner::Executor::init_tokio().unwrap();
+
+    // This sets sandbox arena for reactive graph
+    let owner = reactive_graph::owner::Owner::new();
+    owner.set();
+}

--- a/tests_ssr/tests/missing.rs
+++ b/tests_ssr/tests/missing.rs
@@ -1,6 +1,7 @@
 use futures::StreamExt;
 use leptos::prelude::*;
 use leptos_async_signal::*;
+use tests_ssr::init_test;
 
 #[component]
 fn App() -> impl IntoView {
@@ -53,7 +54,8 @@ fn Component(msg_tx: AsyncWriteSignal<String>) -> impl IntoView {
 
 #[tokio::test]
 async fn render_async() {
-    any_spawner::Executor::init_tokio().unwrap();
+    init_test();
+    
     let app = view! { <App /> };
     let html = app.to_html_stream_in_order().collect::<String>().await;
     println!("{html}");

--- a/tests_ssr/tests/single.rs
+++ b/tests_ssr/tests/single.rs
@@ -1,6 +1,7 @@
 use futures::StreamExt;
 use leptos::prelude::*;
 use leptos_async_signal::*;
+use tests_ssr::init_test;
 
 #[component]
 pub fn App() -> impl IntoView {
@@ -52,7 +53,7 @@ fn Component(msg_tx: AsyncWriteSignal<String>) -> impl IntoView {
 
 #[tokio::test]
 async fn render_async() {
-    any_spawner::Executor::init_tokio().unwrap();
+    init_test();
     let app = view! { <App /> };
     let html = app.to_html_stream_in_order().collect::<String>().await;
     assert!(html.contains("msg is: Hello world"));


### PR DESCRIPTION
The SSR tests were failing on workspace build because by default there was no sandbox arena. The manual initialization of arena in tests fixes this.