### PR TITLE
Actually test and fix the handling of unused `AsyncWriteSignal`

### DIFF
--- a/leptos_async_signal/src/lib.rs
+++ b/leptos_async_signal/src/lib.rs
@@ -104,3 +104,10 @@ where
         res
     }
 }
+
+impl<T> Drop for AsyncWriteSignal<T> {
+    fn drop(&mut self) {
+        #[cfg(feature = "ssr")]
+        self.state.mark_ready()
+    }
+}

--- a/tests_ssr/tests/clone_drop.rs
+++ b/tests_ssr/tests/clone_drop.rs
@@ -1,0 +1,56 @@
+use futures::StreamExt;
+use leptos::prelude::*;
+use leptos_async_signal::*;
+use tests_ssr::init_test;
+
+#[component]
+pub fn App() -> impl IntoView {
+    let (msg_res, msg_tx) = async_signal("default message".to_string());
+    view! {
+        <Suspense>
+            { move || {
+                let msg = match msg_res.get() {
+                    None => "no msg yet".to_owned(),
+                    Some(msg) => format!("msg is: {msg}")
+                };
+                view! { <span id="msg">{msg}</span> }
+            }
+        }
+        </Suspense>
+        <Component msg_tx=msg_tx.clone() />
+    }
+}
+
+#[component]
+fn Component(msg_tx: AsyncWriteSignal<String>) -> impl IntoView {
+    let data = ArcResource::new(
+        || (),
+        move |_| {
+            let msg_tx = msg_tx.clone();
+            async move {
+                let (msg, num) = tests_ssr::fetch_data().await;
+                msg_tx.set(msg);
+                num
+            }
+        },
+    );
+    view! {
+        <Suspense>
+            { move || {
+                    match data.get() {
+                        Some(num) => view! { <span>The number is: {num}</span> }.into_any(),
+                        None => view! { <span>No number</span> }.into_any(),
+                    }
+                }
+            }
+        </Suspense>
+    }
+}
+
+#[tokio::test]
+async fn render_async() {
+    init_test();
+    let app = view! { <App /> };
+    let html = app.to_html_stream_in_order().collect::<String>().await;
+    assert!(html.contains("msg is: Hello world"));
+}

--- a/tests_ssr/tests/unused.rs
+++ b/tests_ssr/tests/unused.rs
@@ -1,0 +1,38 @@
+use std::time::Duration;
+
+use futures::StreamExt;
+use leptos::prelude::*;
+use leptos_async_signal::*;
+use tests_ssr::init_test;
+use tokio::time::timeout;
+
+#[component]
+pub fn App() -> impl IntoView {
+    view! {
+        {
+            let (msg_res, _) = async_signal("default message".to_string());
+            view! {
+                <Suspense>
+                    { move || {
+                        let msg = match msg_res.get() {
+                            None => "no msg yet".to_owned(),
+                            Some(msg) => format!("msg is: {msg}")
+                        };
+                        view! { <span id="msg">{msg}</span> }
+                    }
+                }
+                </Suspense>
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn render_async() {
+    init_test();
+    let app = view! { <App /> };
+    let html = timeout(Duration::from_secs(1), app.to_html_stream_in_order().collect::<String>())
+        .await
+        .expect("SSR should not have timed out");
+    assert!(html.contains("msg is: default message"));
+}


### PR DESCRIPTION
Unused `AsyncWriteSignal` with usage of unconstrained `await` on the accompanied `ArcResource` will in fact hang SSR indefinitely as `Notify` will never return.  Provide an `impl Drop` for `feature = "ssr"` that will notify the ready state so the detection of drop [as documented](https://docs.rs/leptos_async_signal/0.4.0/leptos_async_signal/fn.async_signal.html) will correctly function to provide the default value as intended, rather than waiting forever. The `unused` test will validate this, albeit with a timeout, so removing the `impl Drop` will result in the failure in termination rather than waiting forever.

Also modified the `AsyncWriteSIgnal` to be an inner type enclosed in an `Arc` and have the new outer type be the public type, so that `Arc::get_mut` can be leveraged to ensure drop only happens on the final copy, otherwise _any_ drop will invoke `.mark_ready()`, most certainly prematurely, as per the `clone_drop` test. It's not possible to leverage `AsyncState.inner` for this task because the circular dependency due to the resource having copy of this and thus it will hold onto a copy of the very thing it must somehow give up to continue (which it can't).

Alternatively, using timeout in the resource on `state.wait()` inside the resource can also work, as it would best ensure it doesn't wait forever, given how it may be possible to purposefully hide clones to not letting the final drop to prevent this automatic ready state being set, but that's kind of on the user.